### PR TITLE
fix structured data tests.

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -226,7 +226,8 @@ class Breadcrumbs implements BreadcrumbsContract {
 				} else {
 
 					$item = sprintf(
-						'<span itemprop="item">%s</span>',
+						'<span itemscope itemid="%s" itemtype="https://schema.org/WebPage" itemprop="item">%s</span>',
+						esc_url( $url ),
 						$label
 					);
 				}
@@ -242,10 +243,11 @@ class Breadcrumbs implements BreadcrumbsContract {
 
 				// Build the list item.
 				$list .= sprintf(
-					'<%1$s class="%2$s" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">%3$s</%1$s>',
+					'<%1$s class="%2$s" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">%3$s<meta itemprop="position" content="%4$s"/></%1$s>',
 					tag_escape( $this->option( 'item_tag' ) ),
 					esc_attr( join( ' ', $classes ) ),
-					$item
+					$item,
+					$i
 				);
 
 				++$i;


### PR DESCRIPTION
Hey @justintadlock!

I've received an email today via Google Search Console bugging me about validations /shrug , so I've thought of taking a look. 

This PR adds the "webpage" schema on the last item so it can get its URL validated as well as the position IDs of the list.

Can you take a look as well? Thanks for all the hard work on this, looks great 👍 !

**Info for easier debugging if needed:**

Current invalid:
![hb-data-validation](https://user-images.githubusercontent.com/22611066/71451776-3ade4400-2785-11ea-94dc-f1f65032855a.jpg)

Example code:
```
<ul class="breadcrumbs__trail" itemscope="" itemtype="https://schema.org/BreadcrumbList">
	<li class="breadcrumbs__crumb breadcrumbs__crumb--home" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem"><a href="https://xkon.gr/" itemprop="item"><span itemprop="name">Home</span></a></li>
	<li class="breadcrumbs__crumb breadcrumbs__crumb--post" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem"><span itemprop="item"><span itemprop="name">Tattoos</span></span></li>
</ul>
```

After patch:
![hb-data-validation-valid](https://user-images.githubusercontent.com/22611066/71451778-3f0a6180-2785-11ea-90ea-792898535264.jpg)

Example changed code:
```
<ul class="breadcrumbs__trail" itemscope="" itemtype="https://schema.org/BreadcrumbList">
	<li class="breadcrumbs__crumb breadcrumbs__crumb--home" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
		<a href="https://xkon.gr/" itemprop="item"><span itemprop="name">Home</span></a>
		<meta itemprop="position" content="1">
	</li>
	<li class="breadcrumbs__crumb breadcrumbs__crumb--post" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
		<span itemscope="" itemid="https://xkon.gr/tattoos/" itemtype="https://schema.org/WebPage" itemprop="item"><span itemprop="name">Tattoos</span></span>
		<meta itemprop="position" content="2">
	</li>
</ul>
```